### PR TITLE
Fix three bugs found in buyFlower, giftFlower and setForSale functions

### DIFF
--- a/flowersmartcontract.md
+++ b/flowersmartcontract.md
@@ -1,8 +1,9 @@
-# A Detailed Guide on How to Create a Smart Contract for Flowers on the Celo Blockchain.
+# A Detailed Guide on How to Create a Smart Contract for a Flowers Marketplace on the Celo Blockchain
 
 ## INTRODUCTION
 
 **What is Celo?**<br>
+
 
 <img   src="https://coinculture.com/au/wp-content/uploads/2022/07/Celo.jpg" alt="celo img"/>
 
@@ -12,23 +13,24 @@
 
 To take this tutorial, you will need:
 - A desktop computer with internet and a Chrome web browser.
-- A basic understanding of Blockchain technology and smart contracts. If you're not familiar with this, we suggest taking our Introduction to Blockchain course first.
+- A basic understanding of blockchain technology and smart contracts. If you're not familiar with this, we suggest taking our Introduction to Blockchain course first.
 - A desktop computer with internet and a Chrome web browser.
 
 ## REQUIREMENT
-- A code or text editor. This tutorial uses Remix IDE.
+- A code or text editor. This tutorial uses the [Remix IDE](https://remix.ethereum.org/).
 - An internet browser and stable internet connection.
 
 ## Tutorial Overview
 
-In this tutorial, we would be building a smart contract for buying and selling flowers on the celo blockchain. The contract contains a set of rules and conditions that must be met before the transaction can take place. The conditions include the price of the flowers and any other relevant terms. Once the conditions are met, the contract automatically executes the transaction, transferring ownership of the flowers and the payment between the buyer and the seller in a secure, transparent, and tamper-proof manner. This eliminates the need for intermediaries and ensures that the transaction is fair, efficient, and reliable.<br>
+In this tutorial, we would be building a smart contract for buying and selling flowers on the Celo blockchain. The contract contains a set of rules and conditions that must be met before the transaction can take place. The conditions include the price of the flowers and any other relevant terms. Once the conditions are met, the contract automatically executes the transaction, transferring ownership of the flowers and the payment between the buyer and the seller in a secure, transparent, and tamper-proof manner. This eliminates the need for intermediaries and ensures that the transaction is fair, efficient, and reliable.<br>
 
 Now let's begin writing our smart contract.
 
 To get started, we will create a new file on remix called flower.sol. Click on this link to learn how to create a new file on remix [(here)](https://remix-ide.readthedocs.io/en/latest/file_explorer.html#:~:text=Creating%20new%20files,-There%20are%202&text=The%20first%20is%20to%20click,will%20open%20in%20the%20Editor.).
 
 After creating a new file we start by declaring some statements in our smart contract.
-```js
+
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity >=0.7.0 <0.9.0;
@@ -38,7 +40,7 @@ The line SPDX-License-Identifier: MIT is an identifier for the license of the co
 The next line is the declaration of the solidity programming language used in a smart contract, specifically stating that the code is written in Solidity version 0.7.0 or later, but not later than 0.9.0. 
 
 Next, we add our token interface.
-```js
+```solidity
 interface IERC20Token {
   function transfer(address, uint256) external returns (bool);
   function approve(address, uint256) external returns (bool);
@@ -64,7 +66,7 @@ The **IERC20Token** is an interface in the Ethereum network that defines the sta
 Next, we begin by naming our contract and also creating our struct.<br>
 A `struct` in Solidity is a user-defined complex data type that allows you to group multiple variables under a single name. It is used to define a custom type in the contract and can be used to store multiple values of different types under a single object. A struct can contain elements of different data types including other structs, arrays, and mappings.
 
-```js
+```solidity
 contract FloralNft{
     struct Flower{
         address payable owner;
@@ -86,11 +88,12 @@ The next line is the struct called `Flower` which holds information about a uniq
 - `forSale`: a boolean value that indicates whether the flower is for sale or not.<br>
 
 Additionally, to interact with the cUSD token on the Celo alfajores test network, it is necessary to include the address of the token.
-```js
+
+```solidity
  address internal cUsdTokenAddress = 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1;
 ```
 Next, we create our mapping. Click on this link to know more about mapping [(Mapping)](https://medium.com/upstate-interactive/mappings-in-solidity-explained-in-under-two-minutes-ecba88aff96e).
-```js
+```solidity
 mapping (uint => Flower) internal flowers;
     uint internal flowersLength = 0; 
 ```
@@ -99,7 +102,8 @@ The mapping, named "flowers", maps a key of type "uint" (unsigned integer) to a 
 A state variable named `flowersLength` is being declared in the next line as a data type of "uint". This variable will store the number of flowers permanently in the contract and only accept unsigned integer values.<br>
 
 Furthermore, to make our smart contract more interesting we begin to add functions. The first function we will be adding is the create flower function.
-```js
+
+```solidity
 
     function createFlower(
         string memory _name,
@@ -122,7 +126,7 @@ Furthermore, to make our smart contract more interesting we begin to add functio
 The createFlower function creates a new flower and stores it in a mapping named "flowers" where "flowersLength" keeps track of the number of flowers stored. The function takes 5 arguments: _name (the name of the flower), _description (a description of the flower), _image (a URL or reference to the image of the flower), _price (the price of the flower), and _isSale (a boolean indicating if the flower is on sale). The "payable" keyword ensures that the sender of the transaction can pay for the gas required to execute the function. <br>
 
 The next inline is the `getFlower` function.
-```js
+```solidity
   function getFlower(uint _index) public view returns(
         address payable,
         string memory,
@@ -146,8 +150,9 @@ The next inline is the `getFlower` function.
 The getFlower function helps retrieves information about a flower stored in the "flowers" mapping based on its index. The function has one input argument, _index, which is the index of the desired flower in the mapping. The function is marked with the view and public keywords, meaning that it can be executed by any user and does not modify the state of the contract. The function returns the owner's address, name, description, image, price, and sale status of the flower.<br>
 
 Next, we add a buy function that will enable users to purchase flowers from the blockchain.
-```js
-function buyFlower(uint _index)public payable{
+```solidity
+    function buyFlower(uint _index)public payable{
+        require(flowers[_index].forSale, "Flower is not for sale");
         require(
             IERC20Token(cUsdTokenAddress).transferFrom(
                 msg.sender,
@@ -163,12 +168,13 @@ function buyFlower(uint _index)public payable{
 
 The buy function allows a user to purchase a flower that is stored in a mapping called "flowers." The input argument, _index, determines which flower the user wants to buy. The function is marked as payable and public, meaning it can be executed by any user and requires payment in Ether.
 
-The function first checks if the required amount can be transferred from the buyer's account to the seller's account using the transferFrom function of an IERC20 token contract at a specified address. If the transfer fails, an error message "Transaction can not be performed" is thrown. If the transfer succeeds, the flower's forSale status is set to false and the ownership is transferred to the buyer.
+The function first checks if the flower is for sale and then checks if the required amount has been successfully transferred from the buyer's account to the seller's account using the transferFrom function of an IERC20 token contract at a specified address. If the transfer fails, an error message "Transaction can not be performed" is thrown. If the transfer succeeds, the flower's forSale status is set to false and the ownership is transferred to the buyer.
 
 Furthermore, we add a unique function which is the `setForsale` function.
 
-```js
- function setForSale(uint _index)public{
+```solidity
+    function setForSale(uint _index)public{
+        require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");
         flowers[_index].forSale = !flowers[_index].forSale;
     }
 ```
@@ -179,11 +185,11 @@ It works by changing the status of a flower to either "for sale" or "not for sal
 
 The function takes one input, which is the index of the flower that needs to be changed.
 
-Then, the function updates the "forSale" property of the flower at that index to the opposite of its current value. For example, if the "forSale" property was "true", it will now become "false", and if it was "false", it will now become "true".
+Then, the function checks if the sender of the transaction is the flower's owner and if true, it then updates the "forSale" property of the flower at that index to the opposite of its current value. For example, if the "forSale" property was "true", it will now become "false", and if it was "false", it will now become "true".
 
 Finally, we add the `getFlowersLegth` function that will help users know how many flowers are currently in the array, without having to look through the entire array themselves. It provides a quick and easy way to retrieve this information.
 
-```js
+```solidity
  function getFlowerLength() public view returns (uint) {
         return (flowersLength);
     }
@@ -197,7 +203,7 @@ When the function is called, it simply returns the value of a variable called "f
 
 The complete code for this session is provided below.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity >=0.7.0 <0.9.0;
@@ -266,6 +272,7 @@ contract FloralNft{
     }
     
     function buyFlower(uint _index)public payable{
+        require(flowers[_index].forSale, "Flower is not for sale");
         require(
             IERC20Token(cUsdTokenAddress).transferFrom(
                 msg.sender,
@@ -279,9 +286,11 @@ contract FloralNft{
     }
     
     function giftFlower(uint _index, address _address)public{
+        require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");
         flowers[_index].owner = payable(_address);
     }
     function setForSale(uint _index)public{
+        require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");
         flowers[_index].forSale = !flowers[_index].forSale;
     }
     

--- a/flowersmartcontract.md
+++ b/flowersmartcontract.md
@@ -26,7 +26,7 @@ In this tutorial, we would be building a smart contract for buying and selling f
 
 Now let's begin writing our smart contract.
 
-To get started, we will create a new file on remix called flower.sol. Click on this link to learn how to create a new file on remix [(here)](https://remix-ide.readthedocs.io/en/latest/file_explorer.html#:~:text=Creating%20new%20files,-There%20are%202&text=The%20first%20is%20to%20click,will%20open%20in%20the%20Editor.).
+To get started, we will create a new file on Remix called `flower.sol`. Click on this link to learn how to create a new file on Remix [(here)](https://remix-ide.readthedocs.io/en/latest/file_explorer.html#:~:text=Creating%20new%20files,-There%20are%202&text=The%20first%20is%20to%20click,will%20open%20in%20the%20Editor.).
 
 After creating a new file we start by declaring some statements in our smart contract.
 
@@ -35,11 +35,12 @@ After creating a new file we start by declaring some statements in our smart con
 
 pragma solidity >=0.7.0 <0.9.0;
 ```
-The line SPDX-License-Identifier: MIT is an identifier for the license of the code, in this case, the MIT License. The SPDX (Software Package Data Exchange) identifier is a standardized way to identify open-source licenses.<br>
+The line `SPDX-License-Identifier: MIT` is an identifier for the license of the code, in this case, the `MIT License`. [The SPDX (Software Package Data Exchange)](https://spdx.dev/) identifier is a standardized way to identify open-source licenses.<br>
 
-The next line is the declaration of the solidity programming language used in a smart contract, specifically stating that the code is written in Solidity version 0.7.0 or later, but not later than 0.9.0. 
+The next line is the declaration of the version of the Solidity programming language used in the smart contract, specifically stating that the code is written in Solidity version 0.7.0 or later, but not later than 0.9.0. 
 
-Next, we add our token interface.
+Next, we add our ERC20 token interface.
+
 ```solidity
 interface IERC20Token {
   function transfer(address, uint256) external returns (bool);
@@ -54,17 +55,17 @@ interface IERC20Token {
 ```
 
 The **IERC20Token** is an interface in the Ethereum network that defines the standard set of functions that an ERC-20 token contract must implement. It specifies the following functions:
-- transfer: This function allows the transfer of a specified amount of cUSD tokens from the caller's account to another address.
-- approve: This function allows the caller to approve a specified address to transfer a specified amount of cUSD tokens from their account.
-- transferFrom: This function allows us to transfer of a specified amount of cUSD tokens from one address to another if the caller has previously approved the transfer.
-- totalSupply: This function returns the total supply of tokens in the contract.
-- balanceOf: This function returns the balance of cUSD tokens for a specified address.
-- allowance: This function returns the amount of cUSD tokens that a specified spender is approved to transfer from a specified owner's account.
-- Transfer: This is an event that is triggered whenever cUSD tokens are transferred from one address to another.
-- Approval: This is an event that is triggered whenever a transfer of tokens is approved.
+- **transfer**: This function allows the transfer of a specified amount of cUSD tokens from the caller's account to another address.
+- **approve**: This function allows the caller to approve a specified address to transfer a specified amount of cUSD tokens from their account.
+- **transferFrom**: This function allows us to transfer a specified amount of cUSD tokens from one address to another if the caller has previously approved the transfer.
+- **totalSupply**: This function returns the total supply of tokens in the contract.
+- **balanceOf**: This function returns the balance of cUSD tokens for a specified address.
+- **allowance**: This function returns the amount of cUSD tokens that a specified spender is approved to transfer from a specified owner's account.
+- **Transfer**: This is an event that is triggered whenever cUSD tokens are transferred from one address to another.
+- **Approval**: This is an event that is triggered whenever a transfer of tokens is approved.
 
 Next, we begin by naming our contract and also creating our struct.<br>
-A `struct` in Solidity is a user-defined complex data type that allows you to group multiple variables under a single name. It is used to define a custom type in the contract and can be used to store multiple values of different types under a single object. A struct can contain elements of different data types including other structs, arrays, and mappings.
+A `struct` in Solidity is a user-defined complex data type that allows you to group multiple variables under a single name. It is used to define a custom type in the contract and can be used to store multiple values of different types under a single object. A struct can contain elements of different data types including other structs, arrays, and mappings. (Learn more about [structs](https://docs.soliditylang.org/en/v0.8.17/types.html#structs))
 
 ```solidity
 contract FloralNft{
@@ -87,21 +88,22 @@ The next line is the struct called `Flower` which holds information about a uniq
 - `price`: an unsigned integer (uint) that stores the price of the flower.
 - `forSale`: a boolean value that indicates whether the flower is for sale or not.<br>
 
-Additionally, to interact with the cUSD token on the Celo alfajores test network, it is necessary to include the address of the token.
+Additionally, to interact with the cUSD token on the Celo Alfajores test network, it is necessary to include the address of the token.
 
 ```solidity
  address internal cUsdTokenAddress = 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1;
 ```
-Next, we create our mapping. Click on this link to know more about mapping [(Mapping)](https://medium.com/upstate-interactive/mappings-in-solidity-explained-in-under-two-minutes-ecba88aff96e).
+Next, we create our mapping. Click on this link to learn more about mappings [(Mapping)](https://medium.com/upstate-interactive/mappings-in-solidity-explained-in-under-two-minutes-ecba88aff96e).
+
 ```solidity
 mapping (uint => Flower) internal flowers;
     uint internal flowersLength = 0; 
 ```
-The mapping, named "flowers", maps a key of type "uint" (unsigned integer) to a value of type "Flower". This data structure allows for a unique "uint" key to be associated with a specific "Flower" object, allowing for efficient look-up and retrieval of "Flower" values based on their associated keys.<br>
+The mapping, named **"flowers"**, maps a key of type `uint` to a value of type "Flower". This data structure allows for a unique `uint` key to be associated with a specific "Flower" object, allowing for efficient look-up and retrieval of "Flower" values based on their associated keys.<br>
 
-A state variable named `flowersLength` is being declared in the next line as a data type of "uint". This variable will store the number of flowers permanently in the contract and only accept unsigned integer values.<br>
+A state variable named `flowersLength` is being declared in the next line as a data type of `uint`. This variable will store the number of flowers permanently in the contract and only accept unsigned integer values.<br>
 
-Furthermore, to make our smart contract more interesting we begin to add functions. The first function we will be adding is the create flower function.
+Furthermore, to make our smart contract more interesting we begin to add functions. The first function we will be adding is the `createFlower` function.
 
 ```solidity
 
@@ -123,9 +125,18 @@ Furthermore, to make our smart contract more interesting we begin to add functio
         flowersLength++;
     }
 ```
-The createFlower function creates a new flower and stores it in a mapping named "flowers" where "flowersLength" keeps track of the number of flowers stored. The function takes 5 arguments: _name (the name of the flower), _description (a description of the flower), _image (a URL or reference to the image of the flower), _price (the price of the flower), and _isSale (a boolean indicating if the flower is on sale). The "payable" keyword ensures that the sender of the transaction can pay for the gas required to execute the function. <br>
+The `createFlower` function creates a new flower and stores it in a mapping named `flowers` where `flowersLength` keeps track of the number of flowers stored. The function takes 5 parameters:
 
-The next inline is the `getFlower` function.
+1. `_name` - The name of the flower
+2. `_description` - The description of the flower
+3. `_image` - The URL or reference to the image of the flower
+4. `_price` - The price of the flower
+5. `_isSale` - A boolean indicating if the flower is on sale
+
+The `public` keyword ensures that the function can be accessed outside and inside of the smart contract. <br>
+
+Next, we have the `getFlower` function.
+
 ```solidity
   function getFlower(uint _index) public view returns(
         address payable,
@@ -147,9 +158,10 @@ The next inline is the `getFlower` function.
     }
 ```
 
-The getFlower function helps retrieves information about a flower stored in the "flowers" mapping based on its index. The function has one input argument, _index, which is the index of the desired flower in the mapping. The function is marked with the view and public keywords, meaning that it can be executed by any user and does not modify the state of the contract. The function returns the owner's address, name, description, image, price, and sale status of the flower.<br>
+The `getFlower` function helps retrieves information about a flower stored in the `flowers` mapping based on its index. The function has only one parameter, the `_index` which is the index of the desired flower in the mapping. The function is marked with the view and public keywords, meaning that it can be called both externally and internally and does not modify the state of the contract. The function returns the `owner's address`, `name`, `description`, `image`, `price`, and `sale status` of the flower.<br>
 
-Next, we add a buy function that will enable users to purchase flowers from the blockchain.
+Next, we add a `buyFlower` function that will enable users to purchase flowers from the blockchain.
+
 ```solidity
     function buyFlower(uint _index)public payable{
         require(flowers[_index].forSale, "Flower is not for sale");
@@ -166,11 +178,11 @@ Next, we add a buy function that will enable users to purchase flowers from the 
     }
 ```
 
-The buy function allows a user to purchase a flower that is stored in a mapping called "flowers." The input argument, _index, determines which flower the user wants to buy. The function is marked as payable and public, meaning it can be executed by any user and requires payment in Ether.
+The `buyFlower` function allows a user to purchase an existing flower. The input parameter `_index` determines which flower the user wants to buy. The function is marked as `payable` and `public` to allow external access to it.
 
-The function first checks if the flower is for sale and then checks if the required amount has been successfully transferred from the buyer's account to the seller's account using the transferFrom function of an IERC20 token contract at a specified address. If the transfer fails, an error message "Transaction can not be performed" is thrown. If the transfer succeeds, the flower's forSale status is set to false and the ownership is transferred to the buyer.
+The function first checks if the flower is for sale and then checks if the required amount has been successfully transferred from the buyer's account to the seller's account using the `transferFrom` function of the cUSD token. If the transfer fails, an error message "Transaction can not be performed" is thrown. If the transfer succeeds, the flower's `forSale` status is set to false and the ownership is transferred to the buyer.
 
-Furthermore, we add a unique function which is the `setForsale` function.
+Up next is the `setForsale` function.
 
 ```solidity
     function setForSale(uint _index)public{
@@ -179,15 +191,13 @@ Furthermore, we add a unique function which is the `setForsale` function.
     }
 ```
 
-Basically, this function allows a user to toggle the status of a flower in the array between being available for sale or not available for sale. 
+This function allows a user to toggle the `forSale` boolean value of a flower where `true` would mean that the flower is available for sale and `false` would mean it isn't available. 
 
-It works by changing the status of a flower to either "for sale" or "not for sale" in an array of flowers.
+The function takes one parameter `_index` which is the index of the flower that needs to be changed.
 
-The function takes one input, which is the index of the flower that needs to be changed.
+Then, the function checks if the sender of the transaction is the flower's owner, and if true, it then updates the "forSale" property of the flower at that index to the opposite of its current value. For example, if the "forSale" property was "true", it would now become "false", and if it was "false", it would now become "true".
 
-Then, the function checks if the sender of the transaction is the flower's owner and if true, it then updates the "forSale" property of the flower at that index to the opposite of its current value. For example, if the "forSale" property was "true", it will now become "false", and if it was "false", it will now become "true".
-
-Finally, we add the `getFlowersLegth` function that will help users know how many flowers are currently in the array, without having to look through the entire array themselves. It provides a quick and easy way to retrieve this information.
+Finally, we add the `getFlowersLegth` function that will help users know how many flowers are currently in our smart contract's state, without having to look through the entire `flowers` mapping. It provides a quick and easy way to retrieve this information.
 
 ```solidity
  function getFlowerLength() public view returns (uint) {
@@ -195,11 +205,8 @@ Finally, we add the `getFlowersLegth` function that will help users know how man
     }
 ```
 
-This function assists in returning the number of flowers in an array of flowers.
+This function does not take any parameters and returns a `uint` value representing the number of flowers created.
 
-The function does not take any inputs and has a return value of an unsigned integer (uint).
-
-When the function is called, it simply returns the value of a variable called "flowersLength", which presumably stores the current number of flowers in the array.
 
 The complete code for this session is provided below.
 
@@ -302,9 +309,9 @@ contract FloralNft{
 
 ## CONTRACT DEPLOYMENT
 
-To deploy the contract, three things are required: the CeloExtensionWallet [CeloExtensionWallet]((https://chrome.google.com/webstore/detail/celoextensionwallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh?hl=en)), the Celo Faucet [Celo Faucet](https://celo.org/developers/faucet), and the Celo Remix Plugin.
+To deploy the contract, three things are required: the [CeloExtensionWallet]((https://chrome.google.com/webstore/detail/celoextensionwallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh?hl=en)), the [Celo Faucet](https://celo.org/developers/faucet), and the Celo Remix Plugin.
 
-Firstly, you can obtain the CeloExtensionWallet from the Google Chrome store by clicking on the provided link. Once you have downloaded and installed the wallet, create a new wallet and ensure that you keep the key phrase in a safe location to prevent losing your funds permanently.
+Firstly, you can obtain the CeloExtensionWallet from the Google Chrome store by clicking on the provided link. Once you have downloaded and installed the extension, create a new wallet and ensure that you keep the key phrase in a safe location to prevent losing your funds permanently.
 
 After setting up your wallet, you will need to fund it using the Celo Faucet. To do this, copy your wallet's address and navigate to the Celo Faucet link provided above. Next, paste your wallet's address in the text field and confirm the transaction.
 
@@ -328,6 +335,6 @@ Solidity documentation for version 0.8.17: https://docs.soliditylang.org/en/v0.8
 
 I hope these resources prove to be useful to you!
 
-### About the author
+## About the author
 
- I'm Ogoyi Thompson, a web3 developer residing in Nigeria, and I have a strong passion for working with blockchain technology.
+I'm Ogoyi Thompson, a web3 developer residing in Nigeria, and I have a strong passion for working with blockchain technology.

--- a/flowersmartcontract.md
+++ b/flowersmartcontract.md
@@ -197,6 +197,23 @@ The function takes one parameter `_index` which is the index of the flower that 
 
 Then, the function checks if the sender of the transaction is the flower's owner, and if true, it then updates the "forSale" property of the flower at that index to the opposite of its current value. For example, if the "forSale" property was "true", it would now become "false", and if it was "false", it would now become "true".
 
+Next, we add the `giftFlower` function.
+
+```solidity
+    function giftFlower(uint _index, address _address)public{
+        require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");
+        flowers[_index].owner = payable(_address);
+        flowers[_index].forSale = false;
+    }
+```
+
+The `giftFlower` function allows a user to gift a flower they own to another user. The function takes two parameters:
+
+1. `_index` - The index of the flower in the `flowers` mapping 
+2. `_address` - The user's address to gift the flower to
+
+It then checks if the sender of the transaction is the `owner` of the flower, if true, it updates the `owner` of the flower to the `_address` and changes the `forSale` value to `false` as the new `owner` might not want to sell the flower.  
+
 Finally, we add the `getFlowersLegth` function that will help users know how many flowers are currently in our smart contract's state, without having to look through the entire `flowers` mapping. It provides a quick and easy way to retrieve this information.
 
 ```solidity
@@ -295,6 +312,7 @@ contract FloralNft{
     function giftFlower(uint _index, address _address)public{
         require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");
         flowers[_index].owner = payable(_address);
+        flowers[_index].forSale = false;
     }
     function setForSale(uint _index)public{
         require(flowers[_index].owner == msg.sender, "Only the flower's owner can perform this action");


### PR DESCRIPTION
## Improvements and Fixes

1. Used the proper extension for the Solidity code blocks
2. Fixed bug in the **buyFlower** function where users could buy flowers that weren't for sale
3. Fixed bug in **setForSale** and **giftFlower** where users could modify the state of flowers they do not own.

**Updates:**

1. Fixed typos across the tutorials
2. Fixed grammatical and abbreviations errors.
3. Rephrased a few sentences to improve clarity.
4. Rewrote some parts of the explanations to fix unclear and incorrect explanations such as the explanation about the `createFlower` function.
5. Added explanation for the **giftFlower** function which was previously missing in the tutorial
6. Changed use of **arguments** to **parameters** in explanations as these explanations were referring to the function's variables defined and not the arguments passed during the function call. 
7. Made sure that the **forSale** value of a flower is set to false after calling the **giftFlower** function as the new owner might not want the flower to be on sale.